### PR TITLE
Ensure stb_image decoding works with Automatic1111 payloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/build/
+.cache/
+CMakeFiles/
+CMakeCache.txt
+cmake_install.cmake
+Makefile
+compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,105 @@
+cmake_minimum_required(VERSION 3.16)
+project(AIAsciiGachaRPG LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+add_executable(ai_ascii_gacha
+    src/main.cpp
+    src/Character.cpp
+    src/Inventory.cpp
+    src/Gacha.cpp
+    src/AIArtManager.cpp
+    src/Battle.cpp
+    src/Utils.cpp
+    src/HttpClient.cpp
+    src/StbImage.cpp
+)
+
+target_include_directories(ai_ascii_gacha PRIVATE src external)
+
+find_package(Threads REQUIRED)
+target_link_libraries(ai_ascii_gacha PRIVATE Threads::Threads)
+
+if(WIN32)
+    target_link_libraries(ai_ascii_gacha PRIVATE winhttp)
+endif()
+
+set(_ai_gacha_default_use_libcurl ON)
+if(WIN32)
+    set(_ai_gacha_default_use_libcurl OFF)
+endif()
+option(USE_LIBCURL "Enable libcurl integration" ${_ai_gacha_default_use_libcurl})
+
+set(_ai_gacha_default_fetch_curl OFF)
+if(NOT WIN32)
+    set(_ai_gacha_default_fetch_curl ON)
+endif()
+option(AI_GACHA_FETCH_CURL "Automatically fetch and build libcurl if it is missing" ${_ai_gacha_default_fetch_curl})
+if(USE_LIBCURL)
+    find_package(CURL QUIET)
+    if(CURL_FOUND)
+        target_compile_definitions(ai_ascii_gacha PRIVATE USE_LIBCURL=1)
+        target_link_libraries(ai_ascii_gacha PRIVATE CURL::libcurl)
+    elseif(AI_GACHA_FETCH_CURL)
+        set(_ai_gacha_curl_ready FALSE)
+        set(_ai_gacha_curl_version "8.7.1")
+        set(_ai_gacha_curl_archive "${CMAKE_BINARY_DIR}/curl-${_ai_gacha_curl_version}.tar.gz")
+        set(_ai_gacha_curl_src_dir "${CMAKE_BINARY_DIR}/curl-${_ai_gacha_curl_version}")
+        set(_ai_gacha_curl_build_dir "${CMAKE_BINARY_DIR}/curl-${_ai_gacha_curl_version}-build")
+
+        if(EXISTS "${_ai_gacha_curl_src_dir}/CMakeLists.txt")
+            set(_ai_gacha_curl_ready TRUE)
+        else()
+            file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}")
+            message(STATUS "Attempting to download libcurl ${_ai_gacha_curl_version}...")
+            file(DOWNLOAD
+                "https://curl.se/download/curl-${_ai_gacha_curl_version}.tar.gz"
+                "${_ai_gacha_curl_archive}"
+                SHOW_PROGRESS
+                STATUS _ai_gacha_curl_dl_status
+                EXPECTED_HASH SHA256=5bdc541cf74c6cb0cb21e078ff857f440be3c6ba4b543f34816f21024ab2d5a3
+            )
+            list(LENGTH _ai_gacha_curl_dl_status _ai_gacha_curl_status_len)
+            if(_ai_gacha_curl_status_len GREATER 0)
+                list(GET _ai_gacha_curl_dl_status 0 _ai_gacha_curl_status_code)
+            else()
+                set(_ai_gacha_curl_status_code -1)
+            endif()
+
+            if(_ai_gacha_curl_status_code EQUAL 0)
+                execute_process(
+                    COMMAND ${CMAKE_COMMAND} -E tar xzf "${_ai_gacha_curl_archive}"
+                    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+                    RESULT_VARIABLE _ai_gacha_curl_extract_result
+                )
+                if(_ai_gacha_curl_extract_result EQUAL 0)
+                    set(_ai_gacha_curl_ready TRUE)
+                else()
+                    message(WARNING "Failed to extract libcurl archive (error ${_ai_gacha_curl_extract_result}). libcurl support will be disabled. Set AI_GACHA_FETCH_CURL=OFF to silence this message.")
+                endif()
+            else()
+                list(GET _ai_gacha_curl_dl_status 1 _ai_gacha_curl_status_msg)
+                message(WARNING "Failed to download libcurl automatically: ${_ai_gacha_curl_status_msg}. libcurl support will be disabled. Set AI_GACHA_FETCH_CURL=OFF to silence this message.")
+            endif()
+        endif()
+
+        if(_ai_gacha_curl_ready)
+            set(BUILD_CURL_EXE OFF CACHE BOOL "Disable curl command line build" FORCE)
+            set(BUILD_TESTING OFF CACHE BOOL "Disable curl tests" FORCE)
+            add_subdirectory("${_ai_gacha_curl_src_dir}" "${_ai_gacha_curl_build_dir}")
+            target_compile_definitions(ai_ascii_gacha PRIVATE USE_LIBCURL=1)
+            target_link_libraries(ai_ascii_gacha PRIVATE libcurl)
+        else()
+            message(STATUS "Proceeding without libcurl; only placeholder ASCII art will be used.")
+        endif()
+    else()
+        message(WARNING "libcurl was not found and automatic fetching is disabled; AI image services will be unavailable.")
+    endif()
+endif()
+
+option(USE_STB_IMAGE "Enable stb_image based PNG decoding" OFF)
+if(USE_STB_IMAGE)
+    target_compile_definitions(ai_ascii_gacha PRIVATE USE_STB_IMAGE=1)
+endif()

--- a/README.md
+++ b/README.md
@@ -1,2 +1,62 @@
-# AI_battle_for_c-
-c++ lecture assignment
+# AI ASCII Gacha RPG
+
+C++17 콘솔 환경에서 동작하는 가챠 기반 RPG 예제입니다. AI 이미지 생성 파이프라인(HTTP 호출 → ASCII 변환)과 가챠/전투 시스템을 모두 콘솔에서 체험할 수 있도록 구현했습니다.
+
+## 주요 특징
+
+- **가챠 시스템**: `std::mt19937`와 `std::discrete_distribution`을 사용해 1~5성 캐릭터를 확률적으로 뽑습니다.
+- **AI 아트 파이프라인**: 캐릭터를 뽑을 때 콘솔에서 입력한 프롬프트를 기반으로 Stability AI 또는 로컬 Automatic1111 WebUI를 호출하고(`std::async` 비동기 처리), 실패 시 내부 Placeholder ASCII 아트를 생성해 캐시합니다.
+- **ASCII 캐싱**: `.cache/ascii/` 폴더에 캐릭터별 ASCII 아트를 저장하여 동일 캐릭터를 다시 뽑아도 즉시 로딩됩니다.
+- **턴제 전투**: 매 라운드마다 공격/방어/후퇴 중 하나를 직접 선택해 전략적으로 전투를 진행할 수 있습니다.
+
+## 빌드 및 실행
+
+```bash
+cmake -S . -B build
+cmake --build build
+./build/ai_ascii_gacha
+```
+
+> 💡 **Visual Studio (Windows)**
+>
+> 기본 CMake 설정에서는 Windows에서 `USE_LIBCURL=OFF`로 동작하며, 내부 WinHTTP 클라이언트를 사용해 자동으로 HTTP 요청을 처리합니다.
+> 따라서 libcurl이 설치되어 있지 않아도 오류 없이 실행되며, Automatic1111 WebUI와 HTTPS 기반 Stability API 모두 정상적으로 호출됩니다.
+> 만약 명시적으로 libcurl을 사용하고 싶다면 구성 단계에서 `-DUSE_LIBCURL=ON`을 전달하고, 필요하다면 `-DAI_GACHA_FETCH_CURL=ON`으로 소스
+> 다운로드를 허용하세요.
+
+## 환경 변수
+
+### AI 서비스 선택
+
+- `AI_GACHA_PROVIDER`: `stability`, `automatic1111`, `none` 중 하나를 지정합니다. 기본값은 키가 설정되어 있으면 Stability, 그렇지 않으면 로컬 Automatic1111 WebUI(`http://127.0.0.1:7860`)를 시도합니다.
+- `A1111_API_HOST` (선택): Automatic1111 WebUI의 기본 URL. 미설정 시 `http://127.0.0.1:7860`을 사용합니다.
+- `A1111_NEGATIVE_PROMPT` (선택): 모든 요청에 공통으로 붙일 네거티브 프롬프트 문자열.
+- `A1111_API_AUTH` (선택): Automatic1111을 `--api-auth 사용자:비밀번호`로 실행한 경우 동일한 문자열을 지정하면 Basic 인증 헤더를 자동으로 붙입니다.
+- `A1111_API_KEY` / `A1111_API_KEY_HEADER` (선택): 일부 포크(예: ReForge)에서 요구하는 API 키 헤더 값을 설정합니다. 헤더 이름을 생략하면 기본으로 `X-API-Key`를 사용합니다.
+
+### Stability API 사용 시
+
+- `STABILITY_API_KEY`: [Stability API](https://platform.stability.ai/)에서 발급한 개인 키. `Authorization: Bearer <키>` 헤더로 전송됩니다.
+- `STABILITY_ENGINE_ID` (선택): 사용할 엔진 ID. 기본값은 `stable-diffusion-v1-6`입니다.
+- `STABILITY_API_HOST` (선택): API 호스트. 기본값은 `https://api.stability.ai`입니다.
+
+정상적인 PNG → ASCII 변환을 위해서는 `USE_STB_IMAGE` 옵션을 켜고(기본 OFF) `stb_image.h`를 포함한 상태로 빌드해야 합니다. 헤더가 없거나 디코딩이 실패하면 Placeholder ASCII 아트를 사용합니다. Automatic1111/ReForge의 실제 이미지를 ASCII로 확인하려면 다음과 같이 옵션을 켜 주세요.
+
+```bash
+cmake -S . -B build -DUSE_STB_IMAGE=ON
+cmake --build build
+```
+
+## 캐시 위치
+
+- ASCII 아트 캐시: `.cache/ascii/*.txt`
+
+## 의존성
+
+- C++17 이상 컴파일러
+- CMake 3.16+
+- (선택) libcurl – Linux/macOS 등에서 HTTP 클라이언트로 사용합니다. Windows에서는 기본적으로 WinHTTP가 활성화되어 별도 설치가 필요 없
+  습니다. libcurl을 명시적으로 사용하려면 `cmake -DUSE_LIBCURL=ON`으로 재구성하고 `find_package(CURL)`이 성공하도록 환경을 준비하거나
+  `AI_GACHA_FETCH_CURL=ON`으로 소스 다운로드를 허용하면 됩니다.
+
+프로젝트에 포함된 `external/nlohmann/json.hpp`는 nlohmann/json 스타일과 호환되는 경량 구현체입니다.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ cmake -S . -B build -DUSE_STB_IMAGE=ON
 cmake --build build
 ```
 
+> 🔁 **Automatic1111에서 Base64 출력이 비활성화된 경우**
+>
+> 일부 포크(예: ReForge)나 사용자 설정에서 API 응답의 `images` 항목이 Base64 문자열 대신 이미지 파일 경로만 제공될 수 있습니다. 이 경우 현재 사용자 계정에서 해당 경로를 직접 읽어 PNG 데이터를 가져와 ASCII로 변환합니다. 경로가 다른 드라이브에 있거나 접근 권한이 없다면 Placeholder ASCII가 사용되므로, WebUI가 저장하는 디렉터리에 대한 읽기 권한을 확보해 주세요.
+
 ## 캐시 위치
 
 - ASCII 아트 캐시: `.cache/ascii/*.txt`

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ C++17 콘솔 환경에서 동작하는 가챠 기반 RPG 예제입니다. AI 이
 - **가챠 시스템**: `std::mt19937`와 `std::discrete_distribution`을 사용해 1~5성 캐릭터를 확률적으로 뽑습니다.
 - **AI 아트 파이프라인**: 캐릭터를 뽑을 때 콘솔에서 입력한 프롬프트를 기반으로 Stability AI 또는 로컬 Automatic1111 WebUI를 호출하고(`std::async` 비동기 처리), 실패 시 내부 Placeholder ASCII 아트를 생성해 캐시합니다.
 - **ASCII 캐싱**: `.cache/ascii/` 폴더에 캐릭터별 ASCII 아트를 저장하여 동일 캐릭터를 다시 뽑아도 즉시 로딩됩니다.
+- **이미지 캐싱**: Automatic1111에서 내려받은 PNG 이미지를 `.cache/images/`에 저장하고, ASCII 캐시가 비어 있을 때도 PNG만으로 다시 변환할 수 있습니다.
 - **턴제 전투**: 매 라운드마다 공격/방어/후퇴 중 하나를 직접 선택해 전략적으로 전투를 진행할 수 있습니다.
 
 ## 빌드 및 실행
@@ -49,11 +50,12 @@ cmake --build build
 
 > 🔁 **Automatic1111에서 Base64 출력이 비활성화된 경우**
 >
-> 일부 포크(예: ReForge)나 사용자 설정에서 API 응답의 `images` 항목이 Base64 문자열 대신 이미지 파일 경로만 제공될 수 있습니다. 이 경우 현재 사용자 계정에서 해당 경로를 직접 읽어 PNG 데이터를 가져와 ASCII로 변환합니다. 경로가 다른 드라이브에 있거나 접근 권한이 없다면 Placeholder ASCII가 사용되므로, WebUI가 저장하는 디렉터리에 대한 읽기 권한을 확보해 주세요.
+> 일부 포크(예: ReForge)나 사용자 설정에서 API 응답의 `images` 항목이 Base64 문자열 대신 이미지 파일 경로만 제공될 수 있습니다. 이제 응답이 Base64이든 파일 경로이든 상관없이 PNG 데이터를 `.cache/images/`에 복사한 뒤 ASCII로 변환합니다. PNG만 남아 있는 상황에서도 동일 폴더의 파일을 읽어 ASCII 캐시를 재생성하므로, WebUI가 이미지를 저장하는 디렉터리에 대한 읽기 권한만 확보하면 됩니다.
 
 ## 캐시 위치
 
 - ASCII 아트 캐시: `.cache/ascii/*.txt`
+- PNG 이미지 캐시: `.cache/images/*.png`
 
 ## 의존성
 

--- a/external/nlohmann/json.hpp
+++ b/external/nlohmann/json.hpp
@@ -1,0 +1,467 @@
+#pragma once
+
+#include <cctype>
+#include <cmath>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <variant>
+#include <vector>
+#include <sstream>
+
+namespace nlohmann {
+
+class json {
+public:
+    using object_t = std::map<std::string, json>;
+    using array_t = std::vector<json>;
+    using string_t = std::string;
+    using boolean_t = bool;
+    using number_t = double;
+    using variant_t = std::variant<std::nullptr_t, boolean_t, number_t, string_t, object_t, array_t>;
+
+    json() : data_(nullptr) {}
+    json(std::nullptr_t) : data_(nullptr) {}
+    json(boolean_t value) : data_(value) {}
+    json(int value) : data_(static_cast<number_t>(value)) {}
+    json(long long value) : data_(static_cast<number_t>(value)) {}
+    json(number_t value) : data_(value) {}
+    json(const char* value) : data_(string_t(value)) {}
+    json(const string_t& value) : data_(value) {}
+    json(string_t&& value) : data_(std::move(value)) {}
+    json(const object_t& value) : data_(value) {}
+    json(object_t&& value) : data_(std::move(value)) {}
+    json(const array_t& value) : data_(value) {}
+    json(array_t&& value) : data_(std::move(value)) {}
+
+    static json object() {
+        return json(object_t{});
+    }
+
+    static json array() {
+        return json(array_t{});
+    }
+
+    bool is_null() const { return std::holds_alternative<std::nullptr_t>(data_); }
+    bool is_boolean() const { return std::holds_alternative<boolean_t>(data_); }
+    bool is_number() const { return std::holds_alternative<number_t>(data_); }
+    bool is_string() const { return std::holds_alternative<string_t>(data_); }
+    bool is_object() const { return std::holds_alternative<object_t>(data_); }
+    bool is_array() const { return std::holds_alternative<array_t>(data_); }
+
+    json& operator[](const std::string& key) {
+        if (!is_object()) {
+            data_ = object_t{};
+        }
+        return std::get<object_t>(data_)[key];
+    }
+
+    const json& operator[](const std::string& key) const {
+        static json null_json;
+        if (!is_object()) {
+            return null_json;
+        }
+        auto it = std::get<object_t>(data_).find(key);
+        if (it == std::get<object_t>(data_).end()) {
+            return null_json;
+        }
+        return it->second;
+    }
+
+    json& operator[](size_t index) {
+        if (!is_array()) {
+            throw std::runtime_error("json value is not an array");
+        }
+        auto& arr = std::get<array_t>(data_);
+        if (index >= arr.size()) {
+            throw std::out_of_range("json index out of range");
+        }
+        return arr[index];
+    }
+
+    const json& operator[](size_t index) const {
+        if (!is_array()) {
+            throw std::runtime_error("json value is not an array");
+        }
+        const auto& arr = std::get<array_t>(data_);
+        if (index >= arr.size()) {
+            throw std::out_of_range("json index out of range");
+        }
+        return arr[index];
+    }
+
+    void push_back(const json& value) {
+        if (!is_array()) {
+            data_ = array_t{};
+        }
+        std::get<array_t>(data_).push_back(value);
+    }
+
+    size_t size() const {
+        if (is_array()) {
+            return std::get<array_t>(data_).size();
+        }
+        if (is_object()) {
+            return std::get<object_t>(data_).size();
+        }
+        return 0;
+    }
+
+    bool contains(const std::string& key) const {
+        if (!is_object()) {
+            return false;
+        }
+        const auto& obj = std::get<object_t>(data_);
+        return obj.find(key) != obj.end();
+    }
+
+    template <typename T>
+    T get() const {
+        return get_impl<T>();
+    }
+
+    template <typename T>
+    T value(const std::string& key, const T& default_value) const {
+        if (!is_object()) {
+            return default_value;
+        }
+        const auto& obj = std::get<object_t>(data_);
+        auto it = obj.find(key);
+        if (it == obj.end()) {
+            return default_value;
+        }
+        return it->second.template get<T>();
+    }
+
+    std::string dump(int indent = -1) const {
+        std::ostringstream oss;
+        dump_impl(oss, *this, indent, 0);
+        return oss.str();
+    }
+
+    static json parse(const std::string& input) {
+        size_t index = 0;
+        json result = parse_value(input, index);
+        skip_ws(input, index);
+        if (index != input.size()) {
+            throw std::runtime_error("unexpected trailing characters in json");
+        }
+        return result;
+    }
+
+private:
+    variant_t data_;
+
+    template <typename T>
+    T get_impl() const;
+
+    static void dump_indent(std::ostringstream& oss, int indent, int depth) {
+        if (indent >= 0) {
+            oss << '\n';
+            for (int i = 0; i < depth * indent; ++i) {
+                oss << ' ';
+            }
+        }
+    }
+
+    static void dump_impl(std::ostringstream& oss, const json& value, int indent, int depth) {
+        if (value.is_null()) {
+            oss << "null";
+            return;
+        }
+        if (value.is_boolean()) {
+            oss << (std::get<boolean_t>(value.data_) ? "true" : "false");
+            return;
+        }
+        if (value.is_number()) {
+            number_t num = std::get<number_t>(value.data_);
+            if (std::floor(num) == num) {
+                oss << static_cast<long long>(num);
+            } else {
+                oss << num;
+            }
+            return;
+        }
+        if (value.is_string()) {
+            oss << '"' << escape_string(std::get<string_t>(value.data_)) << '"';
+            return;
+        }
+        if (value.is_array()) {
+            const auto& arr = std::get<array_t>(value.data_);
+            oss << '[';
+            if (!arr.empty()) {
+                for (size_t i = 0; i < arr.size(); ++i) {
+                    if (i > 0) {
+                        oss << ',';
+                    }
+                    dump_indent(oss, indent, depth + 1);
+                    dump_impl(oss, arr[i], indent, depth + 1);
+                }
+                dump_indent(oss, indent, depth);
+            }
+            oss << ']';
+            return;
+        }
+        if (value.is_object()) {
+            const auto& obj = std::get<object_t>(value.data_);
+            oss << '{';
+            bool first = true;
+            for (const auto& [key, val] : obj) {
+                if (!first) {
+                    oss << ',';
+                }
+                first = false;
+                dump_indent(oss, indent, depth + 1);
+                oss << '"' << escape_string(key) << '"' << ':';
+                if (indent >= 0) {
+                    oss << ' ';
+                }
+                dump_impl(oss, val, indent, depth + 1);
+            }
+            if (!obj.empty()) {
+                dump_indent(oss, indent, depth);
+            }
+            oss << '}';
+        }
+    }
+
+    static std::string escape_string(const std::string& input) {
+        std::string result;
+        for (char c : input) {
+            switch (c) {
+                case '\\': result += "\\\\"; break;
+                case '"': result += "\\\""; break;
+                case '\n': result += "\\n"; break;
+                case '\r': result += "\\r"; break;
+                case '\t': result += "\\t"; break;
+                default: result += c; break;
+            }
+        }
+        return result;
+    }
+
+    static void skip_ws(const std::string& input, size_t& index) {
+        while (index < input.size() && std::isspace(static_cast<unsigned char>(input[index]))) {
+            ++index;
+        }
+    }
+
+    static json parse_value(const std::string& input, size_t& index) {
+        skip_ws(input, index);
+        if (index >= input.size()) {
+            throw std::runtime_error("unexpected end of input");
+        }
+        char c = input[index];
+        if (c == 'n') {
+            expect(input, index, "null");
+            return json(nullptr);
+        }
+        if (c == 't') {
+            expect(input, index, "true");
+            return json(true);
+        }
+        if (c == 'f') {
+            expect(input, index, "false");
+            return json(false);
+        }
+        if (c == '"') {
+            return json(parse_string(input, index));
+        }
+        if (c == '[') {
+            return parse_array(input, index);
+        }
+        if (c == '{') {
+            return parse_object(input, index);
+        }
+        if (c == '-' || std::isdigit(static_cast<unsigned char>(c))) {
+            return json(parse_number(input, index));
+        }
+        throw std::runtime_error("invalid json value");
+    }
+
+    static void expect(const std::string& input, size_t& index, const std::string& expected) {
+        if (input.compare(index, expected.size(), expected) != 0) {
+            throw std::runtime_error("unexpected token in json");
+        }
+        index += expected.size();
+    }
+
+    static std::string parse_string(const std::string& input, size_t& index) {
+        if (input[index] != '"') {
+            throw std::runtime_error("expected string");
+        }
+        ++index;
+        std::string result;
+        while (index < input.size()) {
+            char c = input[index++];
+            if (c == '"') {
+                break;
+            }
+            if (c == '\\') {
+                if (index >= input.size()) {
+                    throw std::runtime_error("invalid escape sequence");
+                }
+                char esc = input[index++];
+                switch (esc) {
+                    case '"': result += '"'; break;
+                    case '\\': result += '\\'; break;
+                    case '/': result += '/'; break;
+                    case 'b': result += '\b'; break;
+                    case 'f': result += '\f'; break;
+                    case 'n': result += '\n'; break;
+                    case 'r': result += '\r'; break;
+                    case 't': result += '\t'; break;
+                    default: throw std::runtime_error("unsupported escape sequence");
+                }
+            } else {
+                result += c;
+            }
+        }
+        return result;
+    }
+
+    static number_t parse_number(const std::string& input, size_t& index) {
+        size_t start = index;
+        if (input[index] == '-') {
+            ++index;
+        }
+        while (index < input.size() && std::isdigit(static_cast<unsigned char>(input[index]))) {
+            ++index;
+        }
+        if (index < input.size() && input[index] == '.') {
+            ++index;
+            while (index < input.size() && std::isdigit(static_cast<unsigned char>(input[index]))) {
+                ++index;
+            }
+        }
+        if (index < input.size() && (input[index] == 'e' || input[index] == 'E')) {
+            ++index;
+            if (index < input.size() && (input[index] == '+' || input[index] == '-')) {
+                ++index;
+            }
+            while (index < input.size() && std::isdigit(static_cast<unsigned char>(input[index]))) {
+                ++index;
+            }
+        }
+        return std::stod(input.substr(start, index - start));
+    }
+
+    static json parse_array(const std::string& input, size_t& index) {
+        if (input[index] != '[') {
+            throw std::runtime_error("expected array");
+        }
+        ++index;
+        json result = json::array();
+        skip_ws(input, index);
+        if (index < input.size() && input[index] == ']') {
+            ++index;
+            return result;
+        }
+        while (index < input.size()) {
+            result.push_back(parse_value(input, index));
+            skip_ws(input, index);
+            if (index >= input.size()) {
+                throw std::runtime_error("unexpected end of input in array");
+            }
+            if (input[index] == ',') {
+                ++index;
+                continue;
+            }
+            if (input[index] == ']') {
+                ++index;
+                break;
+            }
+            throw std::runtime_error("expected ',' or ']' in array");
+        }
+        return result;
+    }
+
+    static json parse_object(const std::string& input, size_t& index) {
+        if (input[index] != '{') {
+            throw std::runtime_error("expected object");
+        }
+        ++index;
+        json result = json::object();
+        skip_ws(input, index);
+        if (index < input.size() && input[index] == '}') {
+            ++index;
+            return result;
+        }
+        while (index < input.size()) {
+            skip_ws(input, index);
+            std::string key = parse_string(input, index);
+            skip_ws(input, index);
+            if (index >= input.size() || input[index] != ':') {
+                throw std::runtime_error("expected ':' in object");
+            }
+            ++index;
+            result[key] = parse_value(input, index);
+            skip_ws(input, index);
+            if (index >= input.size()) {
+                throw std::runtime_error("unexpected end of input in object");
+            }
+            if (input[index] == ',') {
+                ++index;
+                continue;
+            }
+            if (input[index] == '}') {
+                ++index;
+                break;
+            }
+            throw std::runtime_error("expected ',' or '}' in object");
+        }
+        return result;
+    }
+};
+
+// Specializations
+
+template <>
+inline std::string json::get<std::string>() const {
+    if (!is_string()) {
+        throw std::runtime_error("json value is not a string");
+    }
+    return std::get<string_t>(data_);
+}
+
+template <>
+inline int json::get<int>() const {
+    if (is_number()) {
+        return static_cast<int>(std::get<number_t>(data_));
+    }
+    throw std::runtime_error("json value is not a number");
+}
+
+template <>
+inline double json::get<double>() const {
+    if (is_number()) {
+        return std::get<number_t>(data_);
+    }
+    throw std::runtime_error("json value is not a number");
+}
+
+template <>
+inline bool json::get<bool>() const {
+    if (is_boolean()) {
+        return std::get<boolean_t>(data_);
+    }
+    throw std::runtime_error("json value is not a boolean");
+}
+
+template <>
+inline json::array_t json::get<json::array_t>() const {
+    if (!is_array()) {
+        throw std::runtime_error("json value is not an array");
+    }
+    return std::get<array_t>(data_);
+}
+
+template <>
+inline json::object_t json::get<json::object_t>() const {
+    if (!is_object()) {
+        throw std::runtime_error("json value is not an object");
+    }
+    return std::get<object_t>(data_);
+}
+
+} // namespace nlohmann

--- a/src/AIArtManager.cpp
+++ b/src/AIArtManager.cpp
@@ -1,0 +1,649 @@
+#include "AIArtManager.h"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <fstream>
+#include <future>
+#include <iostream>
+#include <iomanip>
+#include <ctime>
+#include <cctype>
+#include <sstream>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "Utils.h"
+#include "HttpClient.h"
+
+#include <nlohmann/json.hpp>
+
+#include <functional>
+#include <optional>
+
+#ifdef USE_STB_IMAGE
+#include "stb_image.h"
+#endif
+
+namespace {
+std::string toLower(std::string value) {
+    for (char& ch : value) {
+        ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+    }
+    return value;
+}
+
+std::string ensureTrailingSlash(const std::string& base) {
+    if (base.empty() || base.back() == '/') {
+        return base;
+    }
+    return base + "/";
+}
+
+bool looksLikeBase64(const std::string& value) {
+    if (value.size() < 16) {
+        return false;
+    }
+    size_t usefulChars = 0;
+    for (char ch : value) {
+        if (ch == '\r' || ch == '\n' || ch == ' ' || ch == '\t') {
+            continue;
+        }
+        if (std::isalnum(static_cast<unsigned char>(ch)) || ch == '+' || ch == '/' || ch == '=' || ch == '-' || ch == '_') {
+            ++usefulChars;
+            continue;
+        }
+        return false;
+    }
+    return usefulChars >= 16;
+}
+
+std::string stripDataUriPrefix(const std::string& value) {
+    auto delimiterPos = value.find(',');
+    if (delimiterPos != std::string::npos) {
+        return value.substr(delimiterPos + 1);
+    }
+    return value;
+}
+
+std::optional<std::string> findBase64Image(const nlohmann::json& node) {
+    if (node.is_string()) {
+        std::string candidate = node.get<std::string>();
+        std::string stripped = stripDataUriPrefix(candidate);
+        if (looksLikeBase64(stripped)) {
+            return stripped;
+        }
+        return std::nullopt;
+    }
+
+    if (node.is_array()) {
+        const auto elements = node.get<nlohmann::json::array_t>();
+        for (const auto& element : elements) {
+            auto found = findBase64Image(element);
+            if (found) {
+                return found;
+            }
+        }
+        return std::nullopt;
+    }
+
+    if (node.is_object()) {
+        const auto object = node.get<nlohmann::json::object_t>();
+        static const std::vector<std::string> preferredKeys = {
+            "image", "data", "bytes", "base64", "payload", "content"
+        };
+
+        for (const std::string& key : preferredKeys) {
+            auto it = object.find(key);
+            if (it != object.end()) {
+                auto found = findBase64Image(it->second);
+                if (found) {
+                    return found;
+                }
+            }
+        }
+
+        for (const auto& item : object) {
+            auto found = findBase64Image(item.second);
+            if (found) {
+                return found;
+            }
+        }
+    }
+
+    return std::nullopt;
+}
+
+std::string providerToString(AIServiceProvider provider) {
+    switch (provider) {
+    case AIServiceProvider::Stability:
+        return "Stability";
+    case AIServiceProvider::Automatic1111:
+        return "Automatic1111";
+    case AIServiceProvider::None:
+    default:
+        return "None";
+    }
+}
+} // 익명 네임스페이스 종료
+
+AIArtManager::AIArtManager(const std::string& cacheDir)
+    : cacheDir_(cacheDir), asciiDir_(cacheDir_ + "/ascii"), logPath_(cacheDir_ + "/ai_art.log") {
+    ensureDirectory(cacheDir_);
+    ensureDirectory(asciiDir_);
+
+    std::string providerChoice;
+    if (const char* providerEnv = std::getenv("AI_GACHA_PROVIDER")) {
+        providerChoice = toLower(providerEnv);
+    }
+
+    if (providerChoice == "automatic1111") {
+        config_.provider = AIServiceProvider::Automatic1111;
+    } else if (providerChoice == "stability") {
+        config_.provider = AIServiceProvider::Stability;
+    } else if (providerChoice == "none") {
+        config_.provider = AIServiceProvider::None;
+    }
+
+    if (const char* apiKey = std::getenv("STABILITY_API_KEY")) {
+        config_.apiKey = apiKey;
+        if (config_.provider == AIServiceProvider::None && !config_.apiKey.empty()) {
+            config_.provider = AIServiceProvider::Stability;
+        }
+    }
+
+    if (config_.provider == AIServiceProvider::None) {
+        // 기본값은 로컬 Automatic1111 WebUI를 사용한다고 가정한다.
+        config_.provider = AIServiceProvider::Automatic1111;
+    }
+
+    if (config_.provider == AIServiceProvider::Stability) {
+        if (const char* host = std::getenv("STABILITY_API_HOST")) {
+            config_.host = host;
+        } else {
+            config_.host = "https://api.stability.ai";
+        }
+        if (const char* engine = std::getenv("STABILITY_ENGINE_ID")) {
+            config_.engineId = engine;
+        } else {
+            config_.engineId = "stable-diffusion-v1-6";
+        }
+    } else if (config_.provider == AIServiceProvider::Automatic1111) {
+        if (const char* host = std::getenv("A1111_API_HOST")) {
+            config_.host = host;
+        } else {
+            config_.host = "http://127.0.0.1:7860";
+        }
+        if (const char* auth = std::getenv("A1111_API_AUTH")) {
+            config_.basicAuth = auth;
+        }
+        if (const char* apiKey = std::getenv("A1111_API_KEY")) {
+            config_.apiKeyValue = apiKey;
+        }
+        if (const char* apiKeyHeader = std::getenv("A1111_API_KEY_HEADER")) {
+            config_.apiKeyHeader = apiKeyHeader;
+        } else if (!config_.apiKeyValue.empty()) {
+            config_.apiKeyHeader = "X-API-Key";
+        }
+    }
+
+    if (const char* negative = std::getenv("A1111_NEGATIVE_PROMPT")) {
+        config_.negativePrompt = negative;
+    }
+
+    logMessage("AIArtManager 초기화: provider=" + providerToString(config_.provider) + ", host=" + config_.host);
+}
+
+void AIArtManager::setVerbose(bool verbose) {
+    verbose_ = verbose;
+}
+
+std::string AIArtManager::cacheFilePath(const CharacterTemplate& tmpl, const std::string& userPrompt) const {
+    std::string name = sanitizeFileName(tmpl.name + "_" + std::to_string(tmpl.rarity));
+    std::string hashSuffix = userPrompt.empty() ? "default" : std::to_string(std::hash<std::string>{}(userPrompt));
+    return asciiDir_ + "/" + name + "_" + hashSuffix + ".txt";
+}
+
+bool AIArtManager::loadFromCache(const std::string& path, std::string& asciiArt) const {
+    std::ifstream file(path);
+    if (!file.is_open()) {
+        return false;
+    }
+    asciiArt.assign((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+    return true;
+}
+
+void AIArtManager::saveToCache(const std::string& path, const std::string& asciiArt) const {
+    std::ofstream file(path);
+    if (!file.is_open()) {
+        return;
+    }
+    file << asciiArt;
+}
+
+void AIArtManager::attachAsciiArt(Character& character, const CharacterTemplate& tmpl, const std::string& userPrompt) {
+    std::string cachePath = cacheFilePath(tmpl, userPrompt);
+    std::string fallback = placeholderAscii(tmpl);
+    std::string asciiArt;
+    bool cacheValid = false;
+
+    if (loadFromCache(cachePath, asciiArt)) {
+        if (asciiArt == fallback) {
+            logMessage("캐시에 플레이스홀더 ASCII가 저장되어 있어 무시합니다: " + cachePath);
+        } else {
+            cacheValid = true;
+            logMessage("캐시 히트: " + cachePath);
+        }
+    }
+
+    if (!cacheValid) {
+        logMessage("캐시 미스 발생: " + cachePath + ", 새로운 ASCII 아트를 생성합니다.");
+        auto placeholderFlag = std::make_shared<std::atomic<bool>>(true);
+        auto future = std::async(std::launch::async, [this, tmpl, userPrompt, fallback, placeholderFlag]() {
+            bool usedPlaceholder = true;
+            std::string ascii = requestAsciiFromService(tmpl, userPrompt, fallback, usedPlaceholder);
+            placeholderFlag->store(usedPlaceholder);
+            return ascii;
+        });
+        showLoadingAnimation(future);
+        asciiArt = future.get();
+        bool usedPlaceholder = placeholderFlag->load();
+        if (!usedPlaceholder) {
+            saveToCache(cachePath, asciiArt);
+            logMessage("새 ASCII 아트를 캐시에 저장했습니다: " + cachePath);
+            character.artCachePath = cachePath;
+        } else {
+            logMessage("플레이스홀더 ASCII는 캐시에 저장하지 않습니다: " + cachePath);
+            character.artCachePath.clear();
+        }
+    } else {
+        character.artCachePath = cachePath;
+    }
+
+    if (asciiArt.empty()) {
+        asciiArt = fallback;
+    }
+
+    character.asciiArt = asciiArt;
+}
+
+std::string AIArtManager::placeholderAscii(const CharacterTemplate& tmpl) const {
+    return generatePlaceholderAsciiArt(tmpl.name, tmpl.rarity);
+}
+
+namespace {
+std::vector<unsigned char> decodeBase64(const std::string& input) {
+    static const std::string chars =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    std::vector<int> lookup(256, -1);
+    for (size_t i = 0; i < chars.size(); ++i) {
+        lookup[static_cast<unsigned char>(chars[i])] = static_cast<int>(i);
+    }
+
+    std::vector<unsigned char> output;
+    std::string sanitized;
+    sanitized.reserve(input.size());
+    for (unsigned char c : input) {
+        if (c == '-') {
+            sanitized.push_back('+');
+        } else if (c == '_') {
+            sanitized.push_back('/');
+        } else if (c != '\r' && c != '\n' && c != '\t' && c != ' ') {
+            sanitized.push_back(static_cast<char>(c));
+        }
+    }
+
+    int val = 0;
+    int valb = -8;
+    for (unsigned char c : sanitized) {
+        if (lookup[c] == -1) {
+            if (c == '=') {
+                break;
+            }
+            continue;
+        }
+        val = (val << 6) + lookup[c];
+        valb += 6;
+        if (valb >= 0) {
+            output.push_back(static_cast<unsigned char>((val >> valb) & 0xFF));
+            valb -= 8;
+        }
+    }
+    return output;
+}
+
+std::string encodeBase64(const std::string& input) {
+    static const std::string chars =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    std::string output;
+    int val = 0;
+    int valb = -6;
+    for (unsigned char c : input) {
+        val = (val << 8) + c;
+        valb += 8;
+        while (valb >= 0) {
+            output.push_back(chars[(val >> valb) & 0x3F]);
+            valb -= 6;
+        }
+    }
+    if (valb > -6) {
+        output.push_back(chars[((val << 8) >> (valb + 8)) & 0x3F]);
+    }
+    while (output.size() % 4 != 0) {
+        output.push_back('=');
+    }
+    return output;
+}
+
+std::string convertImageToAscii(const std::vector<unsigned char>& image) {
+    if (image.empty()) {
+        return {};
+    }
+#ifdef USE_STB_IMAGE
+    int width = 0;
+    int height = 0;
+    int channels = 0;
+    unsigned char* data = stbi_load_from_memory(image.data(), static_cast<int>(image.size()), &width, &height, &channels, 3);
+    if (!data) {
+        return {};
+    }
+
+    std::vector<float> grayscale(width * height, 0.0f);
+    for (int y = 0; y < height; ++y) {
+        for (int x = 0; x < width; ++x) {
+            int index = (y * width + x) * 3;
+            float r = static_cast<float>(data[index]) / 255.0f;
+            float g = static_cast<float>(data[index + 1]) / 255.0f;
+            float b = static_cast<float>(data[index + 2]) / 255.0f;
+            float luminance = 0.299f * r + 0.587f * g + 0.114f * b;
+            grayscale[y * width + x] = luminance;
+        }
+    }
+
+    stbi_image_free(data);
+
+    return renderAsciiFromGrayscale(grayscale, width, height, 64);
+#else
+    // stb_image가 없으면 바이너리 이미지 데이터를 디코딩할 수 없다.
+    // 빈 문자열을 반환해 호출 측에서 플레이스홀더 아트로 대체하도록 한다.
+    return {};
+#endif
+}
+} // 익명 네임스페이스 종료
+
+std::string AIArtManager::buildPrompt(const CharacterTemplate& tmpl, const std::string& userPrompt) const {
+    std::ostringstream oss;
+    if (!tmpl.prompt.empty()) {
+        oss << tmpl.prompt;
+    }
+    if (!userPrompt.empty()) {
+        if (oss.tellp() > 0) {
+            oss << ", ";
+        }
+        oss << userPrompt;
+    }
+    if (oss.tellp() > 0) {
+        oss << ", ";
+    }
+    oss << "hero portrait, dramatic lighting";
+    return oss.str();
+}
+
+std::string AIArtManager::requestAsciiFromService(const CharacterTemplate& tmpl, const std::string& userPrompt,
+    const std::string& fallbackAscii, bool& usedPlaceholder) {
+    std::string ascii = fallbackAscii;
+    usedPlaceholder = true;
+
+    if (config_.provider == AIServiceProvider::Stability) {
+        logMessage("Stability API 요청 시작: " + tmpl.name);
+        ascii = requestViaStability(tmpl, userPrompt, ascii);
+    } else if (config_.provider == AIServiceProvider::Automatic1111) {
+        logMessage("Automatic1111 API 요청 시작: " + tmpl.name);
+        ascii = requestViaAutomatic1111(tmpl, userPrompt, ascii);
+    }
+
+    usedPlaceholder = (ascii == fallbackAscii);
+    return ascii;
+}
+
+std::string AIArtManager::requestViaStability(const CharacterTemplate& tmpl, const std::string& userPrompt,
+    const std::string& fallbackAscii) {
+    if (config_.apiKey.empty() || config_.host.empty() || config_.engineId.empty()) {
+        logMessage("Stability API 구성 값이 부족해 플레이스홀더를 사용합니다.");
+        return fallbackAscii;
+    }
+
+    std::string url = ensureTrailingSlash(config_.host) + "v1/generation/" + config_.engineId + "/text-to-image";
+    nlohmann::json payload = nlohmann::json::object();
+    nlohmann::json prompt = nlohmann::json::object();
+    prompt["text"] = buildPrompt(tmpl, userPrompt);
+    nlohmann::json prompts = nlohmann::json::array();
+    prompts.push_back(prompt);
+    payload["text_prompts"] = prompts;
+    payload["cfg_scale"] = 7.0;
+    payload["steps"] = 30;
+    payload["height"] = 512;
+    payload["width"] = 512;
+
+    std::string ascii = fallbackAscii;
+    HttpResponse httpResponse;
+    std::string errorMessage;
+    std::vector<std::pair<std::string, std::string>> headers = {
+        {"Content-Type", "application/json"},
+        {"Accept", "application/json"},
+        {"Authorization", "Bearer " + config_.apiKey}
+    };
+
+    if (httpPost(url, payload.dump(), headers, httpResponse, errorMessage)) {
+        if (httpResponse.status != 200) {
+            std::string statusMsg = "Stability API 응답 코드: " + std::to_string(httpResponse.status);
+            if (verbose_) {
+                std::cerr << "[AIArt] " << statusMsg << '\n';
+            }
+            logMessage(statusMsg);
+        }
+        bool convertedSuccessfully = false;
+        try {
+            auto json = nlohmann::json::parse(httpResponse.body);
+            if (json.contains("artifacts")) {
+                const auto& artifacts = json["artifacts"];
+                if (artifacts.is_array()) {
+                    for (size_t i = 0; i < artifacts.size(); ++i) {
+                        const auto& artifact = artifacts[i];
+                        if (!artifact.contains("base64")) {
+                            continue;
+                        }
+                        std::string finishReason = artifact.value<std::string>("finishReason", "SUCCESS");
+                        if (finishReason != "SUCCESS") {
+                            continue;
+                        }
+                        std::string base64Data = artifact.value<std::string>("base64", "");
+                        std::vector<unsigned char> decoded = decodeBase64(base64Data);
+                        std::string converted = convertImageToAscii(decoded);
+                        if (!converted.empty()) {
+                            ascii = converted;
+                            convertedSuccessfully = true;
+                            break;
+                        }
+                    }
+                }
+            }
+        } catch (const std::exception&) {
+            // 파싱/변환 오류는 무시하고 플레이스홀더 아트로 되돌아간다.
+        }
+        if (!convertedSuccessfully) {
+            std::string warn = "Stability API 응답에서 유효한 이미지를 찾지 못했습니다. 플레이스홀더를 사용합니다.";
+            if (verbose_) {
+                std::cerr << "[AIArt] " << warn << '\n';
+            }
+            logMessage(warn);
+        }
+    } else {
+        std::string err = "Stability API 호출 실패: " + errorMessage;
+        if (verbose_) {
+            std::cerr << "[AIArt] " << err << '\n';
+        }
+        logMessage(err);
+    }
+    if (ascii == fallbackAscii) {
+        logMessage("Stability API 결과가 플레이스홀더로 유지되었습니다.");
+    } else {
+        logMessage("Stability API 결과를 ASCII 아트로 변환했습니다.");
+    }
+    return ascii;
+}
+
+std::string AIArtManager::requestViaAutomatic1111(const CharacterTemplate& tmpl, const std::string& userPrompt,
+    const std::string& fallbackAscii) {
+    if (config_.host.empty()) {
+        logMessage("Automatic1111 호스트가 비어 있어 플레이스홀더를 사용합니다.");
+        return fallbackAscii;
+    }
+
+    std::string url = ensureTrailingSlash(config_.host) + "sdapi/v1/txt2img";
+    nlohmann::json payload = nlohmann::json::object();
+    payload["prompt"] = buildPrompt(tmpl, userPrompt);
+    if (!config_.negativePrompt.empty()) {
+        payload["negative_prompt"] = config_.negativePrompt;
+    }
+    payload["cfg_scale"] = 7.0;
+    payload["steps"] = 30;
+    payload["width"] = 512;
+    payload["height"] = 512;
+
+    std::string ascii = fallbackAscii;
+    HttpResponse httpResponse;
+    std::string errorMessage;
+    std::vector<std::pair<std::string, std::string>> headers = {
+        {"Content-Type", "application/json"}
+    };
+    if (!config_.basicAuth.empty()) {
+        headers.emplace_back("Authorization", "Basic " + encodeBase64(config_.basicAuth));
+    }
+    if (!config_.apiKeyHeader.empty() && !config_.apiKeyValue.empty()) {
+        headers.emplace_back(config_.apiKeyHeader, config_.apiKeyValue);
+    }
+
+    if (httpPost(url, payload.dump(), headers, httpResponse, errorMessage)) {
+        if (httpResponse.status != 200) {
+            std::string statusMsg = "Automatic1111 응답 코드: " + std::to_string(httpResponse.status);
+            if (verbose_) {
+                std::cerr << "[AIArt] " << statusMsg << '\n';
+            }
+            logMessage(statusMsg);
+        }
+        bool convertedSuccessfully = false;
+        try {
+            auto json = nlohmann::json::parse(httpResponse.body);
+            auto handleCandidate = [&](const nlohmann::json& candidateNode, const char* debugSource) {
+                auto base64Candidate = findBase64Image(candidateNode);
+                if (!base64Candidate) {
+                    return false;
+                }
+
+                std::vector<unsigned char> decoded = decodeBase64(*base64Candidate);
+                if (decoded.empty()) {
+                    std::string where = debugSource ? std::string(debugSource) : std::string("알 수 없는 경로");
+                    logMessage("Automatic1111 Base64 디코딩이 실패했습니다 (" + where + ")");
+                    return false;
+                }
+
+                std::string converted = convertImageToAscii(decoded);
+                if (converted.empty()) {
+                    std::string where = debugSource ? std::string(debugSource) : std::string("알 수 없는 경로");
+#ifdef USE_STB_IMAGE
+                    logMessage("Automatic1111 PNG 디코딩에 실패했습니다 (" + where + ")");
+#else
+                    logMessage("USE_STB_IMAGE가 비활성화되어 PNG 데이터를 ASCII로 변환하지 못했습니다 (" + where + ")");
+#endif
+                    return false;
+                }
+
+                ascii = converted;
+                convertedSuccessfully = true;
+                if (debugSource) {
+                    logMessage(std::string("Automatic1111 응답에서 Base64 이미지를 추출했습니다 (출처: ") + debugSource + ")");
+                }
+                return true;
+            };
+
+            if (json.contains("images")) {
+                const auto& images = json["images"];
+                if (images.is_array()) {
+                    const auto imageArray = images.get<nlohmann::json::array_t>();
+                    for (const auto& imageEntry : imageArray) {
+                        if (handleCandidate(imageEntry, "images 배열")) {
+                            break;
+                        }
+                    }
+                } else {
+                    handleCandidate(images, "images 객체");
+                }
+            }
+
+            if (!convertedSuccessfully) {
+                handleCandidate(json, "최상위 응답");
+            }
+        } catch (const std::exception&) {
+            // 파싱/변환 오류는 무시하고 플레이스홀더 아트로 되돌아간다.
+        }
+        if (!convertedSuccessfully) {
+            std::string warn = "Automatic1111 응답에서 유효한 이미지를 찾지 못했습니다. 플레이스홀더를 사용합니다.";
+            if (verbose_) {
+                std::cerr << "[AIArt] " << warn << '\n';
+            }
+            logMessage(warn);
+        }
+    } else {
+        std::string err = "Automatic1111 호출 실패: " + errorMessage;
+        if (verbose_) {
+            std::cerr << "[AIArt] " << err << '\n';
+        }
+        logMessage(err);
+    }
+    if (ascii == fallbackAscii) {
+        logMessage("Automatic1111 결과가 플레이스홀더로 유지되었습니다.");
+    } else {
+        logMessage("Automatic1111 결과를 ASCII 아트로 변환했습니다.");
+    }
+    return ascii;
+}
+
+
+void AIArtManager::showLoadingAnimation(std::future<std::string>& future) const {
+    if (!verbose_) {
+        future.wait();
+        return;
+    }
+
+    static const char spinner[] = {'|', '/', '-', '\\'};
+    size_t index = 0;
+    using namespace std::chrono_literals;
+    while (future.wait_for(200ms) != std::future_status::ready) {
+        std::cout << "\rAI 아트를 생성 중... " << spinner[index % 4] << std::flush;
+        ++index;
+    }
+    std::cout << "\rAI 아트를 생성 중... 완료!    \n";
+}
+
+void AIArtManager::logMessage(const std::string& message) const {
+    std::lock_guard<std::mutex> lock(logMutex_);
+    std::ofstream file(logPath_, std::ios::app);
+    if (!file.is_open()) {
+        return;
+    }
+
+    auto now = std::chrono::system_clock::now();
+    std::time_t nowTime = std::chrono::system_clock::to_time_t(now);
+    std::tm timeInfo{};
+
+#if defined(_WIN32)
+    localtime_s(&timeInfo, &nowTime);
+#else
+    localtime_r(&nowTime, &timeInfo);
+#endif
+
+    file << '[' << std::put_time(&timeInfo, "%F %T") << "] " << message << '\n';
+}

--- a/src/AIArtManager.h
+++ b/src/AIArtManager.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <future>
+#include <mutex>
+#include <string>
+
+#include "Character.h"
+
+enum class AIServiceProvider {
+    None,
+    Stability,
+    Automatic1111
+};
+
+struct AIServiceConfig {
+    std::string host;
+    std::string engineId;
+    std::string apiKey;
+    std::string negativePrompt;
+    std::string basicAuth;
+    std::string apiKeyHeader;
+    std::string apiKeyValue;
+    AIServiceProvider provider{AIServiceProvider::None};
+};
+
+class AIArtManager {
+public:
+    explicit AIArtManager(const std::string& cacheDir = ".cache");
+
+    void attachAsciiArt(Character& character, const CharacterTemplate& tmpl, const std::string& userPrompt);
+    void setVerbose(bool verbose);
+
+private:
+    std::string cacheDir_;
+    std::string asciiDir_;
+    std::string logPath_;
+    AIServiceConfig config_;
+    bool verbose_{true};
+    mutable std::mutex logMutex_;
+
+    std::string cacheFilePath(const CharacterTemplate& tmpl, const std::string& userPrompt) const;
+    bool loadFromCache(const std::string& path, std::string& asciiArt) const;
+    void saveToCache(const std::string& path, const std::string& asciiArt) const;
+
+    std::string requestAsciiFromService(const CharacterTemplate& tmpl, const std::string& userPrompt,
+        const std::string& fallbackAscii, bool& usedPlaceholder);
+    std::string buildPrompt(const CharacterTemplate& tmpl, const std::string& userPrompt) const;
+    std::string placeholderAscii(const CharacterTemplate& tmpl) const;
+
+    void showLoadingAnimation(std::future<std::string>& future) const;
+    void logMessage(const std::string& message) const;
+
+    std::string requestViaStability(const CharacterTemplate& tmpl, const std::string& userPrompt,
+        const std::string& fallbackAscii);
+    std::string requestViaAutomatic1111(const CharacterTemplate& tmpl, const std::string& userPrompt,
+        const std::string& fallbackAscii);
+};

--- a/src/AIArtManager.h
+++ b/src/AIArtManager.h
@@ -34,16 +34,20 @@ private:
     std::string cacheDir_;
     std::string asciiDir_;
     std::string logPath_;
+    std::string imageDir_;
     AIServiceConfig config_;
     bool verbose_{true};
     mutable std::mutex logMutex_;
 
     std::string cacheFilePath(const CharacterTemplate& tmpl, const std::string& userPrompt) const;
+    std::string imageCachePath(const CharacterTemplate& tmpl, const std::string& userPrompt) const;
     bool loadFromCache(const std::string& path, std::string& asciiArt) const;
     void saveToCache(const std::string& path, const std::string& asciiArt) const;
+    bool rebuildAsciiFromImageCache(const std::string& imagePath, std::string& asciiArt) const;
+    void saveImageToCache(const std::string& imagePath, const std::vector<unsigned char>& bytes) const;
 
     std::string requestAsciiFromService(const CharacterTemplate& tmpl, const std::string& userPrompt,
-        const std::string& fallbackAscii, bool& usedPlaceholder);
+        const std::string& fallbackAscii, bool& usedPlaceholder, const std::string& imageCachePath);
     std::string buildPrompt(const CharacterTemplate& tmpl, const std::string& userPrompt) const;
     std::string placeholderAscii(const CharacterTemplate& tmpl) const;
 
@@ -51,7 +55,7 @@ private:
     void logMessage(const std::string& message) const;
 
     std::string requestViaStability(const CharacterTemplate& tmpl, const std::string& userPrompt,
-        const std::string& fallbackAscii);
+        const std::string& fallbackAscii, const std::string& imageCachePath);
     std::string requestViaAutomatic1111(const CharacterTemplate& tmpl, const std::string& userPrompt,
-        const std::string& fallbackAscii);
+        const std::string& fallbackAscii, const std::string& imageCachePath);
 };

--- a/src/Battle.cpp
+++ b/src/Battle.cpp
@@ -1,0 +1,147 @@
+#include "Battle.h"
+
+#include <algorithm>
+#include <chrono>
+#include <iostream>
+#include <limits>
+#include <random>
+#include <thread>
+
+namespace {
+enum class PlayerAction {
+    Attack = 1,
+    Defend = 2,
+    Retreat = 3
+};
+
+PlayerAction promptPlayerAction() {
+    while (true) {
+        std::cout << "행동을 선택하세요 (1. 공격  2. 방어  3. 후퇴): ";
+        int choice = 0;
+        if (!(std::cin >> choice)) {
+            std::cin.clear();
+            std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+            std::cout << "숫자를 입력해주세요.\n";
+            continue;
+        }
+        std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+        if (choice >= static_cast<int>(PlayerAction::Attack) && choice <= static_cast<int>(PlayerAction::Retreat)) {
+            return static_cast<PlayerAction>(choice);
+        }
+        std::cout << "올바른 행동을 선택해주세요.\n";
+    }
+}
+} // 익명 네임스페이스 종료
+
+BattleSystem::BattleSystem()
+    : rng_(static_cast<unsigned int>(std::chrono::high_resolution_clock::now().time_since_epoch().count())) {}
+
+Enemy BattleSystem::createEnemy(const std::vector<Character*>& team) const {
+    double avgRarity = 1.0;
+    if (!team.empty()) {
+        double sum = 0.0;
+        for (const Character* c : team) {
+            sum += c->rarity;
+        }
+        avgRarity = sum / static_cast<double>(team.size());
+    }
+    Enemy enemy;
+    enemy.name = "Void Wraith";
+    enemy.hp = static_cast<int>(200 + avgRarity * 60 + team.size() * 30);
+    enemy.attack = static_cast<int>(35 + avgRarity * 8);
+    return enemy;
+}
+
+void BattleSystem::runBattle(std::vector<Character*> team) {
+    if (team.empty()) {
+        std::cout << "팀에 편성된 캐릭터가 없습니다.\n";
+        return;
+    }
+
+    for (Character* member : team) {
+        if (member) {
+            member->resetHP();
+        }
+    }
+
+    Enemy enemy = createEnemy(team);
+    std::cout << "\n적이 등장했다! " << enemy.name << " (HP: " << enemy.hp << ", ATK: " << enemy.attack << ")\n";
+
+    int round = 1;
+    bool playerRetreated = false;
+    using namespace std::chrono_literals;
+    while (enemy.hp > 0) {
+        bool anyAlive = std::any_of(team.begin(), team.end(), [](const Character* c) { return c && c->isAlive(); });
+        if (!anyAlive) {
+            break;
+        }
+
+        std::cout << "\n-- 라운드 " << round++ << " --\n";
+        PlayerAction action = promptPlayerAction();
+
+        bool defending = false;
+        switch (action) {
+            case PlayerAction::Attack:
+                for (Character* member : team) {
+                    if (!member || !member->isAlive()) {
+                        continue;
+                    }
+                    int damage = member->attack;
+                    enemy.hp = std::max(0, enemy.hp - damage);
+                    std::cout << member->name << "의 공격! (" << damage << " 피해) -> 적 HP: " << enemy.hp << "\n";
+                    std::this_thread::sleep_for(200ms);
+                    if (enemy.hp <= 0) {
+                        break;
+                    }
+                }
+                break;
+            case PlayerAction::Defend:
+                defending = true;
+                std::cout << "팀이 방어 자세를 취했습니다! 적의 공격이 약화됩니다.\n";
+                break;
+            case PlayerAction::Retreat: {
+                std::bernoulli_distribution retreatChance(0.6);
+                if (retreatChance(rng_)) {
+                    std::cout << "성공적으로 후퇴했습니다!\n";
+                    playerRetreated = true;
+                } else {
+                    std::cout << "후퇴에 실패했습니다...\n";
+                }
+                break;
+            }
+        }
+
+        if (enemy.hp <= 0 || playerRetreated) {
+            break;
+        }
+
+        std::vector<Character*> aliveMembers;
+        for (Character* member : team) {
+            if (member && member->isAlive()) {
+                aliveMembers.push_back(member);
+            }
+        }
+        if (aliveMembers.empty()) {
+            break;
+        }
+
+        std::uniform_int_distribution<size_t> dist(0, aliveMembers.size() - 1);
+        Character* target = aliveMembers[dist(rng_)];
+        int incomingDamage = enemy.attack;
+        if (defending) {
+            incomingDamage = std::max(1, incomingDamage / 2);
+        }
+        target->currentHP = std::max(0, target->currentHP - incomingDamage);
+        std::cout << enemy.name << "의 반격! " << target->name << "에게 " << incomingDamage
+                  << " 피해 -> 남은 HP: " << target->currentHP << "\n";
+        std::this_thread::sleep_for(200ms);
+    }
+
+    if (playerRetreated) {
+        std::cout << "\n전투에서 안전하게 빠져나왔습니다.\n";
+    } else if (enemy.hp <= 0) {
+        std::cout << "\n승리! 적을 물리쳤습니다.\n";
+    } else {
+        std::cout << "\n패배... 팀이 전멸했습니다.\n";
+    }
+}

--- a/src/Battle.h
+++ b/src/Battle.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <random>
+#include <string>
+#include <vector>
+
+#include "Character.h"
+
+struct Enemy {
+    std::string name;
+    int hp{0};
+    int attack{0};
+};
+
+class BattleSystem {
+public:
+    BattleSystem();
+
+    void runBattle(std::vector<Character*> team);
+
+private:
+    Enemy createEnemy(const std::vector<Character*>& team) const;
+    mutable std::mt19937 rng_;
+};

--- a/src/Character.cpp
+++ b/src/Character.cpp
@@ -1,0 +1,57 @@
+#include "Character.h"
+
+#include <sstream>
+
+Character::Character(int idValue, const CharacterTemplate& tmpl)
+    : id(idValue),
+      name(tmpl.name),
+      rarity(tmpl.rarity),
+      maxHP(tmpl.baseHP),
+      attack(tmpl.baseATK),
+      skill(tmpl.skill),
+      currentHP(tmpl.baseHP) {}
+
+void Character::resetHP() {
+    currentHP = maxHP;
+}
+
+bool Character::isAlive() const {
+    return currentHP > 0;
+}
+
+nlohmann::json Character::toJson() const {
+    nlohmann::json data = nlohmann::json::object();
+    data["id"] = id;
+    data["name"] = name;
+    data["rarity"] = rarity;
+    data["maxHP"] = maxHP;
+    data["attack"] = attack;
+    data["skill"] = skill;
+    data["asciiArt"] = asciiArt;
+    data["artCachePath"] = artCachePath;
+    return data;
+}
+
+Character Character::fromJson(const nlohmann::json& data) {
+    Character result;
+    result.id = data.value<int>("id", 0);
+    result.name = data.value<std::string>("name", "Unknown");
+    result.rarity = data.value<int>("rarity", 1);
+    result.maxHP = data.value<int>("maxHP", 0);
+    result.attack = data.value<int>("attack", 0);
+    result.skill = data.value<std::string>("skill", "");
+    result.asciiArt = data.value<std::string>("asciiArt", "");
+    result.artCachePath = data.value<std::string>("artCachePath", "");
+    result.currentHP = result.maxHP;
+    return result;
+}
+
+std::string rarityToString(int rarity) {
+    switch (rarity) {
+        case 5: return "★★★★★";
+        case 4: return "★★★★";
+        case 3: return "★★★";
+        case 2: return "★★";
+        default: return "★";
+    }
+}

--- a/src/Character.cpp
+++ b/src/Character.cpp
@@ -29,6 +29,7 @@ nlohmann::json Character::toJson() const {
     data["skill"] = skill;
     data["asciiArt"] = asciiArt;
     data["artCachePath"] = artCachePath;
+    data["artImagePath"] = artImagePath;
     return data;
 }
 
@@ -42,6 +43,7 @@ Character Character::fromJson(const nlohmann::json& data) {
     result.skill = data.value<std::string>("skill", "");
     result.asciiArt = data.value<std::string>("asciiArt", "");
     result.artCachePath = data.value<std::string>("artCachePath", "");
+    result.artImagePath = data.value<std::string>("artImagePath", "");
     result.currentHP = result.maxHP;
     return result;
 }

--- a/src/Character.h
+++ b/src/Character.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+struct CharacterTemplate {
+    std::string name;
+    int rarity{};
+    int baseHP{};
+    int baseATK{};
+    std::string skill;
+    std::string prompt;
+};
+
+struct Character {
+    int id{0};
+    std::string name;
+    int rarity{1};
+    int maxHP{0};
+    int attack{0};
+    std::string skill;
+    std::string asciiArt;
+    std::string artCachePath;
+    int currentHP{0};
+
+    Character() = default;
+    Character(int id, const CharacterTemplate& tmpl);
+
+    void resetHP();
+    bool isAlive() const;
+
+    nlohmann::json toJson() const;
+    static Character fromJson(const nlohmann::json& data);
+};
+
+std::string rarityToString(int rarity);

--- a/src/Character.h
+++ b/src/Character.h
@@ -23,6 +23,7 @@ struct Character {
     std::string skill;
     std::string asciiArt;
     std::string artCachePath;
+    std::string artImagePath;
     int currentHP{0};
 
     Character() = default;

--- a/src/Gacha.cpp
+++ b/src/Gacha.cpp
@@ -1,0 +1,64 @@
+#include "Gacha.h"
+
+#include <algorithm>
+#include <chrono>
+#include <random>
+#include <stdexcept>
+
+#include "AIArtManager.h"
+#include "Inventory.h"
+
+GachaSystem::GachaSystem()
+    : rng_(static_cast<unsigned int>(std::chrono::high_resolution_clock::now().time_since_epoch().count())) {
+    rarityLevels_ = {1, 2, 3, 4, 5};
+    std::vector<double> weights = {40.0, 30.0, 15.0, 10.0, 5.0};
+    rarityDistribution_ = std::discrete_distribution<int>(weights.begin(), weights.end());
+
+    templatesByRarity_[1] = {
+        {"Glimmer Slime", 1, 120, 18, "Sticky Tackle", "A cheerful slime made of shimmering jelly"},
+        {"Rusty Squire", 1, 140, 16, "Shield Bash", "A rookie knight with dented armor but a bright smile"}
+    };
+    templatesByRarity_[2] = {
+        {"Wind Ranger", 2, 180, 28, "Gale Arrow", "An agile archer controlling a swirl of leaves"},
+        {"Tide Cleric", 2, 200, 24, "Healing Wave", "A priestess calling tides of healing water"}
+    };
+    templatesByRarity_[3] = {
+        {"Arc Forge", 3, 240, 36, "Thunder Hammer", "A cyborg blacksmith forging lightning"},
+        {"Crimson Dancer", 3, 220, 40, "Blazing Waltz", "A warrior dancing amid petals of flame"}
+    };
+    templatesByRarity_[4] = {
+        {"Nebula Oracle", 4, 280, 48, "Starfall Prophecy", "A mystic floating in a cosmic observatory"},
+        {"Aurora Valkyrie", 4, 300, 52, "Radiant Strike", "A valkyrie wielding aurora colored wings"}
+    };
+    templatesByRarity_[5] = {
+        {"Eclipse Dragon", 5, 360, 72, "Solar Eclipse", "A dragon woven from sun and moon"},
+        {"Chrono Empress", 5, 320, 68, "Time Collapse", "A regal mage bending time around her"}
+    };
+}
+
+const CharacterTemplate& GachaSystem::randomTemplateForRarity(int rarity) {
+    auto it = templatesByRarity_.find(rarity);
+    if (it == templatesByRarity_.end() || it->second.empty()) {
+        throw std::runtime_error("No templates for rarity");
+    }
+    std::uniform_int_distribution<size_t> dist(0, it->second.size() - 1);
+    return it->second[dist(rng_)];
+}
+
+Character GachaSystem::rollCharacter(AIArtManager& artManager, const std::string& userPrompt) {
+    int rarityIndex = rarityDistribution_(rng_);
+    int rarity = rarityLevels_[rarityIndex];
+    const CharacterTemplate& tmpl = randomTemplateForRarity(rarity);
+
+    Character character(nextId_++, tmpl);
+    artManager.attachAsciiArt(character, tmpl, userPrompt);
+    return character;
+}
+
+void GachaSystem::syncNextId(const Inventory& inventory) {
+    int maxId = 0;
+    for (const auto& character : inventory.getCharacters()) {
+        maxId = std::max(maxId, character.id);
+    }
+    nextId_ = std::max(nextId_, maxId + 1);
+}

--- a/src/Gacha.h
+++ b/src/Gacha.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <map>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "Character.h"
+
+class AIArtManager;
+class Inventory;
+
+class GachaSystem {
+public:
+    GachaSystem();
+
+    Character rollCharacter(AIArtManager& artManager, const std::string& userPrompt);
+    void syncNextId(const Inventory& inventory);
+
+private:
+    std::map<int, std::vector<CharacterTemplate>> templatesByRarity_;
+    std::vector<int> rarityLevels_;
+    std::mt19937 rng_;
+    std::discrete_distribution<int> rarityDistribution_;
+    int nextId_{1};
+
+    const CharacterTemplate& randomTemplateForRarity(int rarity);
+};

--- a/src/HttpClient.cpp
+++ b/src/HttpClient.cpp
@@ -1,0 +1,204 @@
+#include "HttpClient.h"
+
+#ifdef USE_LIBCURL
+#include <curl/curl.h>
+#endif
+
+#ifdef _WIN32
+#include <windows.h>
+#include <winhttp.h>
+#endif
+
+namespace {
+#ifdef USE_LIBCURL
+size_t curlWriteCallback(void* contents, size_t size, size_t nmemb, void* userp) {
+    size_t totalSize = size * nmemb;
+    auto* buffer = static_cast<std::string*>(userp);
+    buffer->append(static_cast<const char*>(contents), totalSize);
+    return totalSize;
+}
+#endif
+
+#ifdef _WIN32
+std::wstring widen(const std::string& input) {
+    if (input.empty()) {
+        return {};
+    }
+    int required = MultiByteToWideChar(CP_UTF8, 0, input.c_str(), -1, nullptr, 0);
+    if (required <= 0) {
+        return {};
+    }
+    std::wstring output(static_cast<size_t>(required), L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, input.c_str(), -1, output.data(), required);
+    if (!output.empty() && output.back() == L'\0') {
+        output.pop_back();
+    }
+    return output;
+}
+#endif
+}
+
+bool httpPost(const std::string& url,
+    const std::string& payload,
+    const std::vector<std::pair<std::string, std::string>>& headers,
+    HttpResponse& response,
+    std::string& errorMessage) {
+#ifdef USE_LIBCURL
+    CURL* curl = curl_easy_init();
+    if (!curl) {
+        errorMessage = "curl_easy_init 실패";
+        return false;
+    }
+
+    std::string responseBuffer;
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_POST, 1L);
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, payload.c_str());
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, payload.size());
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curlWriteCallback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &responseBuffer);
+
+    struct curl_slist* headerList = nullptr;
+    for (const auto& header : headers) {
+        std::string line = header.first + ": " + header.second;
+        headerList = curl_slist_append(headerList, line.c_str());
+    }
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headerList);
+
+    CURLcode res = curl_easy_perform(curl);
+    if (res != CURLE_OK) {
+        errorMessage = curl_easy_strerror(res);
+        if (headerList) {
+            curl_slist_free_all(headerList);
+        }
+        curl_easy_cleanup(curl);
+        return false;
+    }
+
+    long status = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status);
+    response.status = status;
+    response.body = std::move(responseBuffer);
+
+    if (headerList) {
+        curl_slist_free_all(headerList);
+    }
+    curl_easy_cleanup(curl);
+    return true;
+#elif defined(_WIN32)
+    URL_COMPONENTS components{};
+    components.dwStructSize = sizeof(URL_COMPONENTS);
+    components.dwHostNameLength = -1;
+    components.dwUrlPathLength = -1;
+    components.dwSchemeLength = -1;
+
+    std::wstring wUrl = widen(url);
+    if (wUrl.empty() || !WinHttpCrackUrl(wUrl.c_str(), 0, 0, &components)) {
+        errorMessage = "URL 파싱 실패";
+        return false;
+    }
+
+    bool secure = components.nScheme == INTERNET_SCHEME_HTTPS;
+    INTERNET_PORT port = components.nPort;
+    std::wstring host(components.lpszHostName, components.dwHostNameLength);
+    std::wstring path(components.lpszUrlPath, components.dwUrlPathLength);
+
+    HINTERNET session = WinHttpOpen(L"AIAsciiGacha/1.0",
+        WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY,
+        WINHTTP_NO_PROXY_NAME,
+        WINHTTP_NO_PROXY_BYPASS,
+        0);
+    if (!session) {
+        errorMessage = "WinHttpOpen 실패";
+        return false;
+    }
+
+    HINTERNET connection = WinHttpConnect(session, host.c_str(), port, 0);
+    if (!connection) {
+        errorMessage = "WinHttpConnect 실패";
+        WinHttpCloseHandle(session);
+        return false;
+    }
+
+    DWORD flags = secure ? WINHTTP_FLAG_SECURE : 0;
+    HINTERNET request = WinHttpOpenRequest(connection, L"POST", path.c_str(),
+        nullptr, WINHTTP_NO_REFERER, WINHTTP_DEFAULT_ACCEPT_TYPES, flags);
+    if (!request) {
+        errorMessage = "WinHttpOpenRequest 실패";
+        WinHttpCloseHandle(connection);
+        WinHttpCloseHandle(session);
+        return false;
+    }
+
+    std::wstring headerBlock;
+    for (const auto& header : headers) {
+        headerBlock += widen(header.first + ": " + header.second + "\r\n");
+    }
+
+    BOOL sendResult = WinHttpSendRequest(request,
+        headerBlock.empty() ? WINHTTP_NO_ADDITIONAL_HEADERS : headerBlock.c_str(),
+        headerBlock.empty() ? 0 : static_cast<DWORD>(headerBlock.size()),
+        (LPVOID)payload.data(),
+        static_cast<DWORD>(payload.size()),
+        static_cast<DWORD>(payload.size()),
+        0);
+
+    if (!sendResult) {
+        errorMessage = "WinHttpSendRequest 실패";
+        WinHttpCloseHandle(request);
+        WinHttpCloseHandle(connection);
+        WinHttpCloseHandle(session);
+        return false;
+    }
+
+    if (!WinHttpReceiveResponse(request, nullptr)) {
+        errorMessage = "WinHttpReceiveResponse 실패";
+        WinHttpCloseHandle(request);
+        WinHttpCloseHandle(connection);
+        WinHttpCloseHandle(session);
+        return false;
+    }
+
+    DWORD statusCode = 0;
+    DWORD statusSize = sizeof(statusCode);
+    if (WinHttpQueryHeaders(request,
+            WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER,
+            WINHTTP_HEADER_NAME_BY_INDEX,
+            &statusCode,
+            &statusSize,
+            WINHTTP_NO_HEADER_INDEX)) {
+        response.status = static_cast<long>(statusCode);
+    }
+
+    response.body.clear();
+    DWORD bytesAvailable = 0;
+    do {
+        if (!WinHttpQueryDataAvailable(request, &bytesAvailable)) {
+            break;
+        }
+        if (bytesAvailable == 0) {
+            break;
+        }
+        std::string buffer(bytesAvailable, '\0');
+        DWORD bytesRead = 0;
+        if (!WinHttpReadData(request, buffer.data(), bytesAvailable, &bytesRead)) {
+            break;
+        }
+        buffer.resize(bytesRead);
+        response.body.append(buffer);
+    } while (bytesAvailable > 0);
+
+    WinHttpCloseHandle(request);
+    WinHttpCloseHandle(connection);
+    WinHttpCloseHandle(session);
+    return true;
+#else
+    (void)url;
+    (void)payload;
+    (void)headers;
+    (void)response;
+    errorMessage = "HTTP 백엔드가 활성화되어 있지 않습니다.";
+    return false;
+#endif
+}
+

--- a/src/HttpClient.h
+++ b/src/HttpClient.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <string>
+#include <utility>
+#include <vector>
+
+struct HttpResponse {
+    long status{0};
+    std::string body;
+};
+
+// headers are provided as {"Header-Name", "value"}
+// Returns true on successful request and fills response/status.
+// On failure returns false and fills errorMessage for logging.
+bool httpPost(const std::string& url,
+    const std::string& payload,
+    const std::vector<std::pair<std::string, std::string>>& headers,
+    HttpResponse& response,
+    std::string& errorMessage);
+

--- a/src/Inventory.cpp
+++ b/src/Inventory.cpp
@@ -1,0 +1,59 @@
+#include "Inventory.h"
+
+#include <algorithm>
+
+void Inventory::addCharacter(const Character& character) {
+    characters_.push_back(character);
+}
+
+std::vector<Character>& Inventory::getCharacters() {
+    return characters_;
+}
+
+const std::vector<Character>& Inventory::getCharacters() const {
+    return characters_;
+}
+
+Character* Inventory::findById(int id) {
+    auto it = std::find_if(characters_.begin(), characters_.end(), [id](const Character& c) { return c.id == id; });
+    if (it == characters_.end()) {
+        return nullptr;
+    }
+    return &(*it);
+}
+
+const Character* Inventory::findById(int id) const {
+    auto it = std::find_if(characters_.cbegin(), characters_.cend(), [id](const Character& c) { return c.id == id; });
+    if (it == characters_.cend()) {
+        return nullptr;
+    }
+    return &(*it);
+}
+
+void Inventory::setTeam(const std::vector<int>& teamIds) {
+    teamIds_ = teamIds;
+}
+
+const std::vector<int>& Inventory::getTeamIds() const {
+    return teamIds_;
+}
+
+std::vector<Character*> Inventory::getTeamMembers() {
+    std::vector<Character*> result;
+    for (int id : teamIds_) {
+        if (Character* character = findById(id)) {
+            result.push_back(character);
+        }
+    }
+    return result;
+}
+
+std::vector<const Character*> Inventory::getTeamMembers() const {
+    std::vector<const Character*> result;
+    for (int id : teamIds_) {
+        if (const Character* character = findById(id)) {
+            result.push_back(character);
+        }
+    }
+    return result;
+}

--- a/src/Inventory.h
+++ b/src/Inventory.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <optional>
+#include <vector>
+
+#include "Character.h"
+
+class Inventory {
+public:
+    void addCharacter(const Character& character);
+
+    std::vector<Character>& getCharacters();
+    const std::vector<Character>& getCharacters() const;
+
+    Character* findById(int id);
+    const Character* findById(int id) const;
+
+    void setTeam(const std::vector<int>& teamIds);
+    const std::vector<int>& getTeamIds() const;
+
+    std::vector<Character*> getTeamMembers();
+    std::vector<const Character*> getTeamMembers() const;
+
+private:
+    std::vector<Character> characters_;
+    std::vector<int> teamIds_;
+};

--- a/src/StbImage.cpp
+++ b/src/StbImage.cpp
@@ -1,0 +1,8 @@
+#ifdef USE_STB_IMAGE
+// stb_image 구현체를 한 번만 포함하기 위한 전용 소스 파일입니다.
+#define STB_IMAGE_IMPLEMENTATION
+#define STBI_NO_STDIO
+#define STBI_ONLY_PNG
+#define STBI_ONLY_JPEG
+#include "stb_image.h"
+#endif // USE_STB_IMAGE

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -1,0 +1,94 @@
+#include "Utils.h"
+
+#include "Character.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <filesystem>
+#include <sstream>
+
+std::string sanitizeFileName(const std::string& input) {
+    std::string result;
+    for (char c : input) {
+        if (std::isalnum(static_cast<unsigned char>(c))) {
+            result.push_back(c);
+        } else if (c == ' ' || c == '_' || c == '-') {
+            result.push_back('_');
+        }
+    }
+    if (result.empty()) {
+        result = "character";
+    }
+    return result;
+}
+
+char brightnessToAscii(double value) {
+    static const std::string ramp = "@%#*+=-:. ";
+    value = std::clamp(value, 0.0, 1.0);
+    size_t index = static_cast<size_t>(value * (ramp.size() - 1));
+    return ramp[index];
+}
+
+std::string renderAsciiFromGrayscale(const std::vector<float>& grayscale, int width, int height, int targetWidth) {
+    if (width <= 0 || height <= 0 || grayscale.empty()) {
+        return "";
+    }
+    targetWidth = std::max(1, targetWidth);
+    double scaleX = static_cast<double>(width) / static_cast<double>(targetWidth);
+    double scaleY = scaleX * 2.0; // 문자 가로세로 비율을 보정하기 위한 대략적인 스케일
+    int targetHeight = std::max(1, static_cast<int>(std::round(static_cast<double>(height) / scaleY)));
+
+    std::ostringstream oss;
+    for (int y = 0; y < targetHeight; ++y) {
+        for (int x = 0; x < targetWidth; ++x) {
+            int srcX = std::clamp(static_cast<int>(std::round(x * scaleX)), 0, width - 1);
+            int srcY = std::clamp(static_cast<int>(std::round(y * scaleY)), 0, height - 1);
+            double value = grayscale[srcY * width + srcX];
+            oss << brightnessToAscii(value);
+        }
+        if (y + 1 < targetHeight) {
+            oss << '\n';
+        }
+    }
+    return oss.str();
+}
+
+std::string generatePlaceholderAsciiArt(const std::string& name, int rarity) {
+    constexpr int width = 64;
+    constexpr int height = 32;
+    std::vector<float> grayscale(width * height, 0.0f);
+    double centerX = width / 2.0;
+    double centerY = height / 2.0;
+    double radius = std::min(width, height) / 2.0;
+    double rarityBoost = 0.1 * rarity;
+
+    for (int y = 0; y < height; ++y) {
+        for (int x = 0; x < width; ++x) {
+            double dx = (x - centerX) / radius;
+            double dy = (y - centerY) / radius;
+            double dist = std::sqrt(dx * dx + dy * dy);
+            double brightness = std::clamp(1.2 - dist * (1.2 - rarityBoost), 0.0, 1.0);
+            grayscale[y * width + x] = static_cast<float>(brightness);
+        }
+    }
+
+    std::string art = renderAsciiFromGrayscale(grayscale, width, height, 64);
+
+    // 맨 윗줄에 캐릭터 이름 배너를 추가
+    std::ostringstream banner;
+    banner << name << " (" << rarityToString(rarity) << ")";
+    std::string bannerText = banner.str();
+
+    std::ostringstream oss;
+    oss << bannerText << "\n";
+    oss << art;
+    return oss.str();
+}
+
+void ensureDirectory(const std::string& path) {
+    if (path.empty()) {
+        return;
+    }
+    std::filesystem::create_directories(path);
+}

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+std::string sanitizeFileName(const std::string& input);
+char brightnessToAscii(double value);
+std::string renderAsciiFromGrayscale(const std::vector<float>& grayscale, int width, int height, int targetWidth);
+std::string generatePlaceholderAsciiArt(const std::string& name, int rarity);
+void ensureDirectory(const std::string& path);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,155 @@
+#include <iostream>
+#include <limits>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "AIArtManager.h"
+#include "Battle.h"
+#include "Gacha.h"
+#include "Inventory.h"
+
+namespace {
+
+void printMenu() {
+    std::cout << "\n===== AI ASCII 가챠 RPG =====\n";
+    std::cout << "1. 가챠 뽑기\n";
+    std::cout << "2. 인벤토리 보기\n";
+    std::cout << "3. 팀 편성\n";
+    std::cout << "4. 전투 시작\n";
+    std::cout << "0. 종료\n";
+    std::cout << "선택: ";
+}
+
+void showCharacter(const Character& character) {
+    std::cout << "ID: " << character.id << " | " << rarityToString(character.rarity)
+              << " | HP: " << character.maxHP << " | ATK: " << character.attack
+              << " | 스킬: " << character.skill << "\n";
+}
+
+void showInventory(const Inventory& inventory) {
+    const auto& characters = inventory.getCharacters();
+    if (characters.empty()) {
+        std::cout << "인벤토리가 비어 있습니다.\n";
+        return;
+    }
+    std::cout << "\n--- 인벤토리 ---\n";
+    for (const auto& character : characters) {
+        showCharacter(character);
+    }
+
+    std::cout << "\n--- 팀 ---\n";
+    if (inventory.getTeamIds().empty()) {
+        std::cout << "편성된 팀이 없습니다.\n";
+    } else {
+        for (int id : inventory.getTeamIds()) {
+            const Character* c = inventory.findById(id);
+            if (c) {
+                std::cout << "* ";
+                showCharacter(*c);
+            }
+        }
+    }
+}
+
+std::vector<int> parseIds(const std::string& input) {
+    std::vector<int> ids;
+    std::istringstream iss(input);
+    int id = 0;
+    while (iss >> id) {
+        ids.push_back(id);
+    }
+    return ids;
+}
+
+void configureTeam(Inventory& inventory) {
+    const auto& characters = inventory.getCharacters();
+    if (characters.empty()) {
+        std::cout << "먼저 캐릭터를 뽑아주세요.\n";
+        return;
+    }
+
+    std::cout << "편성할 캐릭터의 ID를 공백으로 입력하세요 (최대 3명): ";
+    std::string line;
+    std::getline(std::cin, line);
+    if (line.empty()) {
+        std::getline(std::cin, line);
+    }
+    std::vector<int> ids = parseIds(line);
+    if (ids.size() > 3) {
+        ids.resize(3);
+    }
+
+    std::vector<int> filtered;
+    for (int id : ids) {
+        if (inventory.findById(id)) {
+            filtered.push_back(id);
+        } else {
+            std::cout << "ID " << id << " 캐릭터는 존재하지 않습니다.\n";
+        }
+    }
+    inventory.setTeam(filtered);
+    std::cout << "팀 편성이 완료되었습니다.\n";
+}
+
+void startBattle(Inventory& inventory, BattleSystem& battleSystem) {
+    std::vector<Character*> team = inventory.getTeamMembers();
+    if (team.empty()) {
+        std::cout << "팀이 비어 있습니다. 팀 편성 후 시도해주세요.\n";
+        return;
+    }
+    battleSystem.runBattle(team);
+}
+
+} // 익명 네임스페이스 종료
+
+int main() {
+    GachaSystem gacha;
+    Inventory inventory;
+    AIArtManager artManager;
+    BattleSystem battleSystem;
+
+    bool running = true;
+    while (running) {
+        printMenu();
+        int choice = -1;
+        if (!(std::cin >> choice)) {
+            std::cin.clear();
+            std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+            continue;
+        }
+        std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+
+        switch (choice) {
+            case 1: {
+                std::cout << "이미지 생성을 위한 프롬프트를 입력하세요:\n> ";
+                std::string prompt;
+                std::getline(std::cin, prompt);
+                Character character = gacha.rollCharacter(artManager, prompt);
+                inventory.addCharacter(character);
+                std::cout << "\n새로운 영웅 등장!\n";
+                showCharacter(character);
+                std::cout << "\n" << character.asciiArt << "\n";
+                break;
+            }
+            case 2:
+                showInventory(inventory);
+                break;
+            case 3:
+                configureTeam(inventory);
+                break;
+            case 4:
+                startBattle(inventory, battleSystem);
+                break;
+            case 0:
+                running = false;
+                break;
+            default:
+                std::cout << "올바른 메뉴를 선택하세요.\n";
+                break;
+        }
+    }
+
+    std::cout << "게임을 종료합니다.\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a dedicated stb_image translation unit so USE_STB_IMAGE builds can actually decode returned PNG/JPEG data
- sanitize Automatic1111 base64 responses, log decode failures, and surface clearer diagnostics when conversion falls back to placeholders

## Testing
- cmake -S . -B build
- cmake --build build
- ./build/ai_ascii_gacha <<'EOF'
0
EOF

------
https://chatgpt.com/codex/tasks/task_e_68dde0f38f54832b9028a5c8e8e76803